### PR TITLE
Fix: Correct bashrc.postcustom syntax and finalize bashrc updates

### DIFF
--- a/bashrc.postcustom
+++ b/bashrc.postcustom
@@ -283,6 +283,7 @@ mkvenv() {
         "$python_cmd" -m venv "$venv_dir"
         if [[ $? -ne 0 ]]; then
             echo "[✗] Failed to create virtual environment"
+        fi # Added missing fi for the inner if
     fi
 }
 


### PR DESCRIPTION
- Fixes a syntax error (missing 'fi') in the `mkvenv` function within `bashrc.postcustom`.
- This commit also includes prior changes to `bashrc`:
  - Adds a 'datascience' bash function for environment setup.
  - Adds OpenVINO environment variables.
  - Ensures bashrc.postcustom is loaded reliably from the repository root.
  - Improves Python path handling (alias python3 to python, add common dirs to PATH).
  - Modifies datascience function to use python3 consistently.
  - Fixes evaluation of 'brew shellenv'.
  - Removes an erroneous shebang from mid-file in bashrc.