### PR TITLE
Feat: Make uninstall.sh location independent

### DIFF
--- a/uninstall.sh
+++ b/uninstall.sh
@@ -8,6 +8,9 @@
 
 set -euo pipefail
 
+# Determine the script's directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+
 # Colour helpers
 c_red=$'\033[1;31m'; c_green=$'\033[1;32m'; c_yellow=$'\033[1;33m'; c_blue=$'\033[1;34m'; c_reset=$'\033[0m'
 


### PR DESCRIPTION
Modified uninstall.sh to dynamically determine its own directory. This makes the script more robust and allows it to be run from any location, ensuring that it can correctly perform uninstallation tasks regardless of where the script itself is located.

Tested by running install.sh, then copying uninstall.sh to /tmp and running it from there. Verified that all SENTINEL components were removed from the user's home directory and .bashrc was correctly processed.