### PR TITLE
Create consolidated documentation in docs/ folder

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,18 @@
+# SENTINEL Project Documentation
+
+Welcome to the central documentation for the SENTINEL project. This collection of documents aims to provide comprehensive information about the SENTINEL Secure ENhanced Terminal INtelligent Layer.
+
+## Table of Contents
+
+This documentation is organized into the following sections:
+
+- **[Main Project README](main_readme.md):** The primary overview of the SENTINEL project, its features, and core components.
+- **[Installation Guide](installation.md):** Detailed instructions for installing, reinstalling, and uninstalling SENTINEL.
+- **[TODO List](todo.md):** A list of current tasks and future development plans for the project.
+- **[Error and Warning Report](errors.md):** A summary of static analysis findings and validation for the shell scripts.
+- **[Contributor Documentation (contrib_readme.md)](contrib_readme.md):** Information related to contributions, modules, and additional features provided by contributors.
+- **[Test Scripts Documentation (tests_readme.md)](tests_readme.md):** Information about the testing scripts and helpers for bashrc development.
+- **[Markov Text Generator (markov_readme.md)](markov_readme.md):** Documentation for the SENTINEL Markov chain text generator module.
+- **[External Git Readmes Index (external_git_readmes_index.md)](external_git_readmes_index.md):** An index and explanation for the collection of README files from other Git repositories. These files are located in the `gitstar/readmes/` directory and are not duplicated here.
+
+Please navigate to the respective files for detailed information on each topic.

--- a/docs/contrib_readme.md
+++ b/docs/contrib_readme.md
@@ -1,0 +1,268 @@
+﻿# SENTINEL: Enhanced Bash Environment
+
+![SENTINEL Logo](https://via.placeholder.com/800x200/0d1117/30a14e?text=SENTINEL)
+
+## Overview
+
+SENTINEL (Secure ENhanced Terminal INtelligent Layer) is a comprehensive bash environment enhancement system designed for cybersecurity professionals and power users. This system provides a modular, secure, and feature-rich command-line experience with emphasis on security, productivity, and convenience.
+
+**Version:** 2.0.0
+**Author:** John
+**Last Updates:** 2023-08-14
+
+## Key Features
+
+- **Modular architecture** with dependency management
+- **Enhanced security features** including secure file deletion
+- **Automatic cleanup** on logout to protect sensitive data
+- **Advanced text formatting** utilities
+- **Specialized tools** for cybersecurity workflows (e.g., hashcat integration)
+- **Intelligent prompt** with git status, exit codes, and job count indicators
+- **Path sanitization** to prevent directory traversal attacks
+- **Improved bash completion** for common tools
+
+## Installation
+
+Clone the repository and run the installation script:
+
+```bash
+git clone https://github.com/yourusername/sentinel.git
+cd sentinel
+./install.sh
+```
+
+Or, for manual installation:
+
+```bash
+cp -r sentinel/bash_modules.d ~/.bash_modules.d
+cp sentinel/bash_modules ~/.bash_modules
+cp sentinel/bash_functions ~/.bash_functions
+cp sentinel/bash_aliases ~/.bash_aliases
+cp sentinel/bashrc ~/.bashrc
+# Ensure executable permissions
+chmod +x ~/.bash_modules.d/*.sh ~/.bash_modules.d/*.module
+```
+
+## Core Components
+
+### Secure RM
+
+SENTINEL replaces the standard `rm` command with a secure alternative that prevents file recovery through multiple overwrites.
+
+- **Usage**: Use `rm` as normal; files will be securely deleted by default
+- **Toggle**: Use `secure_rm_toggle` to enable/disable secure deletion
+- **Help**: Type `secure_rm_help` for more information
+
+```bash
+# Example usage
+rm sensitive_file.txt             # Securely deletes the file
+rm -rf sensitive_directory/       # Securely deletes all files in directory
+
+# Disable secure deletion temporarily
+secure_rm_toggle                  # Toggle between secure and standard rm
+```
+
+### Secure Logout
+
+SENTINEL automatically cleans up sensitive data when you log out of your terminal session.
+
+- **Configuration**: Checked via `secure-logout-config`
+- **Customization**: Change settings with `secure-logout-set`
+- **Manual Cleanup**: Use `secure_clean` to trigger cleanup manually
+- **Add Directories**: Use `secure-logout-add-dir` to add directories to cleanup list
+
+```bash
+# View current configuration
+secure-logout-config
+
+# Change settings
+secure-logout-set SENTINEL_SECURE_BROWSER_CACHE 1
+
+# Add a directory to cleanup
+secure-logout-add-dir ~/projects/sensitive-data
+
+# Manually clean all data
+secure_clean all
+
+# Clean specific data type
+secure_clean browser
+```
+
+Items cleaned on logout:
+- Bash history
+- Temporary files
+- Browser cache/cookies (optional)
+- Recently used files list
+- Vim undo history
+- Clipboard contents
+- Custom directories
+
+### Hashcat Module
+
+Enhanced hashcat integration with automatic hash type detection and optimized cracking workflows.
+
+- **Hash Detection**: `hashdetect` automatically identifies hash types
+- **Wordlist Management**: `wordlists` and `rules` commands to manage resources
+- **Targeted Cracking**: `hashcrack_targeted` for efficient multi-phase cracking
+- **Thorough Cracking**: `hashcrack_thorough` for comprehensive multi-vector approaches
+
+```bash
+# Detect hash type
+hashdetect '5f4dcc3b5aa765d61d8327deb882cf99'
+
+# List available resources
+wordlists
+rules
+
+# Crack a hash with auto-detection
+hashcrack '5f4dcc3b5aa765d61d8327deb882cf99'
+
+# Use targeted workflow
+hashcrack_targeted hashes.txt
+
+# Download a new wordlist
+download_wordlist https://example.com/wordlist.txt
+```
+
+### Text Formatting Utilities
+
+Enhanced text processing capabilities for command-line operations.
+
+- **CSV Processing**: `csvview`, `csvsmart`, `csvcolor`
+- **Text Transformations**: `upper`, `lower`, `titlecase`
+- **JSON/XML Formatting**: `jsonpp`, `xmlpp`
+- **Text Filtering**: `nocolor`, `noempty`, `uniqo`
+- **Data Extraction**: Extract IPs, emails, URLs, and cryptographic hashes
+
+```bash
+# Format CSV with proper column alignment
+cat data.csv | csvview
+
+# Remove color codes from output
+command_with_color | nocolor
+
+# Extract all emails from a file
+cat document.txt | extractemail
+
+# Pretty-print JSON with syntax highlighting
+cat data.json | jsonpp
+
+# Count word frequency in a document
+cat document.txt | wordfreq
+```
+
+## Module System
+
+SENTINEL features a robust module system for extending functionality.
+
+### Module Management
+
+- **List Modules**: `module_list`
+- **Enable Module**: `module_enable <module_name>`
+- **Disable Module**: `module_disable <module_name>`
+- **Module Info**: `module_info <module_name>`
+- **Create Module**: `module_create <module_name>`
+
+```bash
+# List all available modules
+module_list
+
+# Enable a module
+module_enable security
+
+# Get detailed information
+module_info hashcat
+
+# Create a new module
+module_create custom_tools
+```
+
+### Available Modules
+
+- **security**: Enhanced security tools and monitoring
+- **productivity**: Task management and time tracking
+- **hashcat**: Password cracking and hash analysis
+- **secure_logout**: Configuration for secure logout behavior
+- **secure_delete**: File deletion with secure overwriting
+
+## Additional Features
+
+### Enhanced Bash Completion
+
+SENTINEL includes improved bash completion scripts for several tools:
+
+- **nmap**: Enhanced completion with script suggestions and advanced options
+- **hashcat**: Automatic completion of hash types and wordlists
+- **others**: Various command-specific enhancements
+
+### Intelligent Prompt
+
+The SENTINEL prompt provides valuable information at a glance:
+
+- Current git branch with status indicator
+- Exit code of previous command
+- Number of background jobs
+- SSH/sudo security indicators
+- Timestamps for command execution
+
+### Virtual Environment Management
+
+Automatically manages Python virtual environments:
+
+- `venvon` / `venvoff`: Toggle automatic venv activation
+- Enhanced `pip` and `pip3` commands that detect when you need a virtual environment
+
+## Security Considerations
+
+SENTINEL includes multiple security-focused features:
+
+- **PATH sanitization** to prevent directory traversal attacks
+- **Secure history** configuration to prevent storing sensitive commands
+- **File permission checks** for critical configuration files
+- **Secure deletion** of sensitive data using multi-pass overwriting
+
+Note: For SSDs and some filesystems, secure deletion may not be completely effective due to wear-leveling and journaling. Full-disk encryption is recommended for maximum security.
+
+## Configuration
+
+SENTINEL can be configured through several methods:
+
+- **~/.bashrc.precustom**: Configure settings before main bashrc loads
+- **~/.bashrc.postcustom**: Override any settings after bashrc loads
+- **~/.bash_modules**: Control which modules are loaded at startup
+- **Module-specific config**: Each module may have its own configuration options
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Module not loading:**
+   - Check permissions: `chmod +x ~/.bash_modules.d/module_name.sh` or `chmod +x ~/.bash_modules.d/module_name.module`
+   - Ensure it's in modules list: `cat ~/.bash_modules`
+
+2. **Secure deletion is slow:**
+   - Toggle off temporarily: `secure_rm_toggle`
+   - For large files, consider using standard deletion with full-disk encryption
+
+3. **Command not found after installation:**
+   - Source your bashrc: `source ~/.bashrc`
+   - Check if module is enabled: `module_list`
+
+### Getting Help
+
+For each module, there is typically a help command available:
+- `hchelp`: Help for hashcat module
+- `secure_rm_help`: Help for secure deletion
+- `secure-logout-config`: Shows configuration for secure logout
+
+## Credits
+
+SENTINEL is based on the original bashrc work by Jason Thistlethwaite (2013), with significant enhancements for modern security and productivity use cases.
+
+## License
+
+Licensed under GNU GPL v2 or later.
+
+---
+
+For more information, visit [GitHub Repository](https://github.com/yourusername/sentinel).

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -1,0 +1,72 @@
+# SENTINEL Shell Script Validation – Error & Warning Report
+
+This document summarizes all issues, warnings, and recommendations found during static analysis and validation of the SENTINEL shell environment scripts.
+
+---
+
+## 1. Syntax Checks
+
+All files passed Bash syntax checks:
+- `~/.bashrc`: OK
+- `bash_modules`: OK
+- `bash_functions`: OK
+- `install.sh`: OK
+
+---
+
+## 2. ShellCheck Static Analysis Warnings
+
+### `~/.bashrc`
+
+- **Line 30:**
+  ```bash
+  declare -A BASHRC_VERSION=(
+  ```
+  **Warning [SC2034]:** `BASHRC_VERSION` appears unused. Verify use (or export if used externally).
+  - *Recommendation:* If this variable is not used elsewhere, consider removing it or exporting if needed by other scripts.
+
+- **Line 39:**
+  ```bash
+  declare -A LOAD_PHASES=(
+  ```
+  **Warning [SC2034]:** `LOAD_PHASES` appears unused. Verify use (or export if used externally).
+  - *Recommendation:* Same as above; remove or export if required.
+
+- **Lines 100, 104:**
+  ```bash
+  source ~/.bashrc.precustom
+  ```
+  **Warning [SC1090]:** ShellCheck can't follow non-constant source. Use a directive to specify location.
+  - *Explanation:* ShellCheck cannot verify the existence of sourced files with variable or user-dependent paths.
+  - *Recommendation:* Ensure these files exist and are secure. This warning can be ignored if you control the environment.
+
+- **Line 131:**
+  ```bash
+  _completion_loader() {
+  ```
+  **Warning [SC2120]:** `_completion_loader` references arguments, but none are ever passed.
+  - *Recommendation:* Review the function to ensure arguments are handled as intended.
+
+---
+
+## 3. Sourcing Test
+
+- Sourcing `~/.bashrc` in a subshell completed successfully: `Sourced OK`
+
+---
+
+## 4. Module System Test
+
+- No errors reported during module system listing.
+
+---
+
+## 5. General Recommendations
+
+- Review all warnings above, especially unused variables and argument handling in functions.
+- Ensure all sourced files (e.g., `~/.bashrc.precustom`) exist and have secure permissions (`chmod 600`).
+- Regularly run `shellcheck` and syntax checks after any changes to these files.
+
+---
+
+**Last updated:** $(date)

--- a/docs/external_git_readmes_index.md
+++ b/docs/external_git_readmes_index.md
@@ -1,0 +1,11 @@
+# Index of External Git Readmes
+
+This section refers to a collection of README files from various external Git repositories that are stored within the SENTINEL project's `gitstar/readmes/` directory.
+
+These files are typically from projects that are relevant to, inspire, or are dependencies/tools used by SENTINEL. They form part of the project's knowledge base.
+
+**Location:** `gitstar/readmes/`
+
+Due to the large number of these external READMEs, they are **not duplicated** into this `docs/` directory. Please refer to the original `gitstar/readmes/` path to browse them.
+
+The files `gitstar/readmes/auto_sort.md` and `gitstar/readmes/UNSORTED/progress.md` (located within the `gitstar/readmes/` directory itself) provide information on how these readmes are curated and organized.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,108 @@
+# SENTINEL Installation Guide
+
+## Overview
+
+The SENTINEL framework provides enhanced security, autocomplete, and Python virtual environment support for your Bash shell. This document explains the installation process and troubleshooting steps.
+
+## Installation
+
+To install SENTINEL:
+
+1. Clone the repository:
+```bash
+git clone https://github.com/username/SENTINEL.git
+cd SENTINEL
+```
+
+2. Run the installer:
+```bash
+bash install.sh
+```
+
+3. Restart your shell or source the configuration:
+```bash
+source ~/.bashrc
+```
+
+## Reinstallation
+
+If you need to completely reinstall SENTINEL:
+
+1. Run the reinstall script:
+```bash
+bash reinstall.sh
+```
+
+2. Restart your shell or source the configuration.
+
+## Uninstallation
+
+To remove SENTINEL from your system:
+
+1. Run the uninstall script:
+```bash
+bash uninstall.sh
+```
+
+2. Remove any remaining configuration files manually if needed.
+
+## Directory Structure
+
+1. Back up your current SENTINEL configuration
+2. Clean up your environment
+3. Remove all SENTINEL components
+
+### Locations
+
+- **Core Framework**: Located in `${HOME}`
+- **Python venv**: Located in `${HOME}/venv`
+- **BLE.sh**: Located in `${HOME}/.local/share/blesh`
+- **Modules**: Located in `${HOME}/bash_modules.d`
+- **Configuration**: Various files in `${HOME}`
+
+## Verification
+
+After installation, verify that SENTINEL was installed correctly:
+
+```bash
+source ${HOME}/bashrc.postcustom
+@autocomplete status
+```
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Autocomplete not working**:
+   - Check that BLE.sh is properly installed
+   - Ensure your .bashrc loads the SENTINEL framework
+   - Try running `@autocomplete fix`
+
+2. **Python environment issues**:
+   - Ensure Python 3.6+ is installed
+   - Check logs in `${HOME}/logs/`
+   - Try reinstalling the venv with `bash reinstall.sh`
+
+3. **Configuration problems**:
+   - Ensure `VENV_AUTO=1` is set in your `${HOME}/bashrc.postcustom`
+   - Check that your .bashrc is sourcing the SENTINEL framework
+   - Check that required Python packages are installed in `${HOME}/venv/`
+
+### Logs
+
+For detailed troubleshooting, check the log files:
+
+- Installation logs: `${HOME}/logs/install.log`
+- Autocomplete logs: `${HOME}/logs/autocomplete-YYYYMMDD.log`
+- Module logs: `${HOME}/logs/module-YYYYMMDD.log`
+
+### Advanced Troubleshooting
+
+1. Check the detailed logs in `${HOME}/logs/`
+2. Run the verification checks: `bash sentinel_postinstall_check.sh`
+3. Try a clean reinstallation: `bash reinstall.sh`
+
+---
+
+- SENTINEL Version: 2.3.0
+- Last Updated: 2025-05-16

--- a/docs/main_readme.md
+++ b/docs/main_readme.md
@@ -1,0 +1,408 @@
+# SENTINEL: Secure ENhanced Terminal INtelligent Layer
+
+![SENTINEL Logo](https://via.placeholder.com/800x200/0d1117/30a14e?text=SENTINEL)
+
+A hardened, optimized, security-focused shell environment for advanced users, researchers, and security professionals, featuring intelligent context-aware assistance, comprehensive autocomplete, environment management, and cybersecurity capabilities.
+
+## Core Features
+
+- **Comprehensive Security**: HMAC verification for module integrity, permission hardening, and execution sandboxing.
+- **Intelligent Command Prediction**: Context-aware suggestions based on history analysis, project context, and statistical modeling.
+- **Enhanced Autocomplete**: A hybrid system providing robust autocompletion:
+  - For the main `sentinel` command and its Bash-based subcommands: Uses standard Bash completion (`bash-completion` package).
+  - For Python-based subcommands and scripts: Uses `argcomplete` for rich, context-aware completions.
+  - Covers:
+    - Commands, arguments, and options.
+    - File paths and directory names.
+    - Dynamic suggestions based on context (e.g., available modules).
+- **Virtual Environment Management**: Automatic Python virtual environment detection, switching, and dependency tracking.
+- **Performance Optimization**: Lazy loading, dependency-based module system, and caching to maintain a responsive terminal.
+
+## Key Components
+
+### Security Focus
+
+- **HMAC Module Verification**: All modules are verified via HMAC to prevent unauthorized modifications.
+- **Permissioned File Operations**: Strict permission controls on all files (600/700).
+- **Logging**: Comprehensive logging with rotation for security auditing.
+- **Safe Execution**: Sandboxed command execution and preview when needed.
+
+### Intelligent Assistance
+
+- **Context-Aware Suggestions**: Commands, arguments, and options based on current context:
+  - Directory contents
+  - Project type
+  - Recent commands
+  - File contents
+  - Command chains (statistical analysis of command sequences)
+
+- **Error Correction**: Automatic correction for common typos and mistakes.
+- **Command Completion**: Multi-level completion with preview for complex operations.
+
+### Advanced Shell Environment
+
+- **Standard Bash Completion**: Integrated with the `bash-completion` framework for robust and performant completions.
+- **`argcomplete` for Python Scripts**: Python-based tools leverage `argcomplete` for detailed and dynamic argument completion.
+- **FZF Integration**: Secure, interactive fuzzy finding (Note: If FZF's completion bindings were tied to BLE.sh, they may need review).
+- **Module System**: Dependency-aware module loading with lazy initialization.
+- **Custom Prompts**: Contextual, information-rich prompts with git status and environment indications.
+
+## Performance Optimizations
+
+### Centralized Configuration Caching System
+
+- **Cached Configuration**: All configuration files are cached in `${HOME}/cache/`
+- **Performance Impact**: Up to 85% reduction in load time for complex configurations
+- **Cache Validation**: Automatic MD5 hash verification to detect changes
+- **Configurable Retention**: Time-based cache expiration settings
+- **Toggle via `SENTINEL_CONFIG_CACHE_ENABLED=1`**
+
+### Benefits:
+
+- **Faster Shell Startup**: Eliminates repeated file parsing overhead
+- **Reduced Disk I/O**: Only reads configurations when changed
+- **Memory Efficiency**: Shared cache across processes
+- **Variable Tracking**: Identifies which variables were set by which file
+
+### Optimized Module Loading
+
+- **Dependency-Aware Loading**: Loads modules in correct dependency order
+- **Lazy Loading**: Modules load only when needed
+- **Path Caching**: Cached module lookup paths for faster initialization
+- **Parallel Loading**: Multi-threaded initialization where possible
+- **Configurable via `SENTINEL_MODULE_CACHE_ENABLED=1`**
+
+### Benefits:
+
+- **Up to 70% Faster Loading**: Dramatic reduction in shell initialization time
+- **Selective Loading**: Only loads what is needed for specific operations
+- **Reduced Resource Usage**: Minimizes RAM and CPU impact during startup
+- **Improved Reliability**: Dependencies handled correctly every time
+
+## Installation
+
+```bash
+# Clone the repository
+git clone https://github.com/yourusername/sentinel.git
+cd sentinel
+
+# Run the installer
+bash install.sh
+
+# Ensure dependencies for autocompletion are met:
+# 1. bash-completion: Usually installed via your system's package manager
+#    (e.g., sudo apt-get install bash-completion). The install.sh script
+#    will attempt to place the sentinel completion file in the correct directory.
+# 2. argcomplete (for Python script completions):
+#    Install via pip: pip install argcomplete --user
+#    Or system-wide: sudo apt-get install python3-argcomplete (Debian/Ubuntu)
+#    The install.sh will provide guidance.
+
+# Restart your shell or source the configuration
+source ~/.bashrc
+```
+
+## Module Configuration
+
+Enable specific modules for customized functionality:
+
+```bash
+# Enable modules in SENTINEL
+vi ~/.bash_modules
+
+echo "sentchat/sentinel_context" >> ~/.bash_modules
+echo "sentchat/sentinel_ml_enhanced" >> ~/.bash_modules
+
+# Reload configuration
+source ~/.bashrc
+```
+
+## Usage Examples
+
+### Intelligent Command Completion
+
+Type a partial command and press Tab to see context-aware suggestions:
+```
+$ git ch<TAB>
+checkout  cherry-pick  cherry  check-ignore  check-mailmap  check-ref-format
+```
+
+With deep completion for arguments and options:
+```
+$ git checkout <TAB>
+main   feature/auth   hotfix/ssl-fix   v2.3.0-RC1   remotes/origin/main
+```
+
+### Command Prediction
+
+The system learns from your workflow patterns:
+```
+$ cd project/
+Suggestions based on context:
+  npm run dev
+  git status
+  code .
+```
+
+### Configuration and Customization
+
+All settings are managed in `${HOME}/config.sh`.
+
+#### Modules
+
+Toggle modules on/off through environment variables or use the TUI:
+
+```bash
+# Enable specific modules
+export SENTINEL_GITSTAR_ENABLED=1
+export SENTINEL_ML_ADVANCED=1
+
+# Reload and apply settings
+sentinel_config_reload
+```
+
+#### Configuration Options
+
+- Enable/disable modules (e.g., `SENTINEL_FZF_ENABLED=1`)
+- Set Python environment settings
+- Configure security verification
+- Set logging levels and locations
+
+##### Cache Configuration:
+- `SENTINEL_CONFIG_CACHE_ENABLED=1` - Master toggle for config caching
+- `SENTINEL_CONFIG_FORCE_REFRESH=0` - Force rebuild all caches
+- `SENTINEL_CONFIG_VERIFY_HASH=1` - Verify cache integrity with MD5
+- `SENTINEL_CONFIG_CACHE_RETENTION_DAYS=30` - Auto-cleanup old caches
+
+##### Module System:
+- `SENTINEL_MODULE_DEBUG=0` - Show detailed module loading info
+- `SENTINEL_MODULE_AUTOLOAD=1` - Auto-load required dependencies
+- `SENTINEL_MODULE_CACHE_ENABLED=1` - Enable module path caching
+- `SENTINEL_MODULE_VERIFY=1` - Security verification for modules
+
+#### Configuration UI
+
+```bash
+./sentinel_toggles_tui.py
+```
+
+#### Migrating Configuration
+
+To transfer configuration from older versions:
+
+```bash
+bash ~/Documents/GitHub/SENTINEL/bash_modules.d/migrate_config.sh
+```
+
+## Major Components
+
+### Autocomplete System
+
+SENTINEL utilizes a hybrid autocompletion system:
+
+-   **Bash Completion (`sentinel-completion.bash`):**
+    -   Handles completions for the main `sentinel` command, its global options (e.g., `--verbose`, `--config`), and any subcommands implemented directly in Bash (e.g., `sentinel module list`).
+    -   Provides file/directory completion for arguments expecting paths.
+    -   Can offer dynamic completions based on context (e.g., listing available modules for `sentinel module load`).
+    -   This script is managed by the standard `bash-completion` framework.
+
+-   **`argcomplete` for Python Scripts:**
+    -   Python-based subcommands or tools (e.g., `sentinel process` which calls `sentinel_process.py`, or scripts in `contrib/`) use `argparse` for argument definition and `argcomplete` for providing completions.
+    *   This allows for rich, type-aware, and choice-aware completions directly from the Python scripts' argument definitions.
+    *   To enable this, Python scripts must include the `PYTHON_ARGCOMPLETE_OK` marker and call `argcomplete.autocomplete(parser)`.
+
+This system ensures performant and relevant completions across the entire SENTINEL framework. Snippet functionality previously tied to `ble.sh` has been disabled as part of this refactor; a new snippet engine would need to be implemented if desired.
+
+### Context-Aware Intelligence
+
+Automatic context detection for:
+
+- Project type (Python, Node.js, Docker, etc.)
+- Git repository status
+- Directory contents and relevance
+- Recent command patterns
+- Terminal dimensions and capabilities
+
+Commands:
+- `sentinel_context` - Show context
+- `sentinel_show_context` - Detailed info
+- `sentinel_update_context` - Manual update
+
+### Command Chain Prediction
+
+Statistically analyze your command sequences to predict next commands:
+
+```bash
+$ git add .
+Next likely command: git commit -m "..."
+$ docker build -t myapp .
+Next likely command: docker run -p 8080:8080 myapp
+```
+
+### Markov Chain Command Generation
+
+Generate command suggestions and documentation using Markov models trained on your command history and documentation sources.
+
+Usage: `sentinel_markov generate -i <input> -o <output>`
+
+### Machine Learning Enhancements
+
+Train on your workflow patterns to improve suggestions and automation with:
+- Command frequency analysis
+- Time-based usage patterns
+- File access correlations
+- Project-specific command sets
+
+Example: `sentinel_ml_stats`, `sentinel_ml_train`
+
+### LLM Chat Integration
+
+Built-in terminal-based chat system with:
+- Context-aware assistance
+- Command proposal and execution
+
+Example: `sentinel_chat`, `/help`, `/context`, `/execute <cmd>`
+
+### Git Repository Intelligence
+
+Enhanced git operations with:
+- Repository statistics and insights
+- Intelligent branch management
+- Commit analytics
+
+Example: `sgtui`, `sentinel_gitstar_fetch`, `sentinel_gitstar_analyze`
+
+## Advanced Configuration
+
+- Edit `${HOME}/config.json`, `chat_config.json`, `cybersec/config.json`, `gitstar/config.json` for advanced settings.
+- Custom prompts: Configure PS1/PS2 variables in bashrc.postcustom
+
+## Security Features
+
+- HMAC validation for all module loading
+- Restricted file permissions (600/700)
+- Input validation for all external sources
+- Sandboxed command evaluation
+
+## Troubleshooting
+
+- `sentinel_config_reload` for diagnostics.
+- To debug Bash completions, you can use `set -x` in your shell before attempting a completion, or add echo statements to `sentinel-completion.bash`.
+- For `argcomplete` issues with a Python script, ensure the script is executable, has the `PYTHON_ARGCOMPLETE_OK` marker, calls `argcomplete.autocomplete()`, and is registered (e.g., via `eval "$(register-python-argcomplete your_script.py)"` or global `argcomplete` activation). Check for errors when running the Python script directly.
+- Check logs: `sentinel_show_logs "component" 50`
+- Check error logs: `cat ~/logs/errors-$(date +%Y%m%d).log`
+- Reset context: `rm -rf ${HOME}/context/*.json`
+- Try restarting the shell session
+- Clear caches: `sentinel_cache_clear`
+- Clear configuration cache: `rm -rf ${HOME}/cache/config/*.cache`
+
+## Contributing
+
+Contributions are welcome! To add new modules:
+
+```bash
+# SENTINEL - My Module
+SENTINEL_MODULE_DESCRIPTION="Description of my module"
+SENTINEL_MODULE_VERSION="1.0.0"
+SENTINEL_MODULE_DEPENDENCIES="logging config_cache"
+
+# Module implementation
+function my_module_command() {
+    # Implementation here
+}
+
+# Export functions
+export -f my_module_command
+```
+
+## Requirements
+
+- Bash 4.0+ (for `bash-completion` and the main shell)
+- `bash-completion` package (standard Linux/macOS utility)
+- Python 3.6+ (with venv support)
+- `argcomplete` Python package (for Python script autocompletion)
+- Git 2.20+
+- Optional: fzf, ripgrep for enhanced functionality
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE](../LICENSE) file for details.
+
+## Documentation
+
+- [SENTINEL Documentation](https://docs.sentinel-framework.org)
+_([Module Development Guide](docs/modules.md) - Note: This file was referenced but not found in the original repository structure.)_
+_([Security Considerations](docs/security.md) - Note: This file was referenced but not found in the original repository structure.)_
+
+## Developer Guide: Adding/Modifying Autocompletions
+
+SENTINEL uses a hybrid autocompletion system. Understanding its components is key to extending it.
+
+### 1. Core Architecture
+
+*   **`sentinel-completion.bash`**: This script (typically installed to `/usr/share/bash-completion/completions/sentinel` or a similar user-local path) handles completions for the main `sentinel` command, its global options, and any subcommands implemented directly as Bash functions within the main `sentinel` script.
+*   **`argcomplete`**: Python scripts (especially those in `contrib/` or those acting as implementations for `sentinel` subcommands like `sentinel process`) use the `argcomplete` library. This allows Python scripts to define their own completions based on their `argparse` definitions.
+
+### 2. Modifying Bash Completions (`sentinel-completion.bash`)
+
+The `sentinel-completion.bash` script contains a main completion function, typically `_sentinel_completions`.
+
+*   **Location**: Find this script in the SENTINEL source or its installed location.
+*   **Structure**:
+    *   The function uses Bash built-ins like `compgen` and helper variables like `COMP_WORDS`, `COMP_CWORD`, `cur`, `prev`.
+    *   The `_get_comp_words_by_ref` function (often included or sourced) is useful for robustly parsing words, especially those containing `=`,`:`.
+    *   A central `case "$cmd"` block (where `cmd` is the current subcommand) dispatches to logic for that subcommand.
+*   **Adding a New Bash Subcommand (e.g., `sentinel newbashcmd`)**:
+    1.  Add `"newbashcmd"` to the `subcommands` array in `_sentinel_completions`.
+    2.  Add a new case to the main `case "$cmd" in ... esac` block:
+        ```bash
+        newbashcmd)
+            # Logic for completing args for newbashcmd
+            # Example: complete from a list of actions
+            if [[ "$cword" -eq 2 ]]; then # Assuming sentinel newbashcmd <action>
+                local actions="action1 action2"
+                COMPREPLY=( $(compgen -W "${actions}" -- "$cur") )
+            # Add more logic for further arguments/options
+            fi
+            ;;
+        ```
+*   **Adding Options to a Bash Subcommand**:
+    *   Locate the `case` block for that subcommand.
+    *   If completing an option (e.g., `if [[ "$cur" == -* ]]; then`), add your new option to the `compgen -W "..."` list for that subcommand's option completions.
+    *   If the option takes an argument, add logic to complete that argument when `prev` is your new option.
+*   **Dynamic Completions**: You can call other shell commands or read files within your completion logic to generate `COMPREPLY` dynamically. For example, `sentinel module unload` reads from `/tmp/sentinel_loaded_modules.txt`.
+*   **File/Directory Completions**: Use the `_filedir` function (provided by `bash-completion`).
+
+### 3. Enabling `argcomplete` for Python Scripts
+
+For Python scripts (e.g., new tools in `contrib/` or scripts that implement a `sentinel` subcommand):
+
+1.  **Use `argparse`**: Ensure your Python script uses `argparse` to define its command-line arguments.
+    ```python
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--my-option", choices=["a", "b"])
+    # ... other arguments
+    ```
+2.  **Add `PYTHON_ARGCOMPLETE_OK` Marker**: Place this comment at the top of your Python script:
+    ```python
+    #!/usr/bin/env python3
+    # PYTHON_ARGCOMPLETE_OK
+    ```
+3.  **Import and Call `argcomplete`**:
+    ```python
+    import argcomplete
+    # ... (define your parser) ...
+    argcomplete.autocomplete(parser)
+    args = parser.parse_args()
+    ```
+    Call `argcomplete.autocomplete(parser)` *before* `parser.parse_args()`.
+4.  **Ensure Script is Executable**: `chmod +x your_script.py`.
+5.  **Registration (for testing/development)**:
+    *   Run `eval "$(register-python-argcomplete your_script.py)"` in your shell.
+    *   The `install.sh` script should handle advising users to install `argcomplete` system-wide or for the user, which often enables these completions automatically without manual registration for every script if global completion is active.
+6.  **Integration with `sentinel` main command (if applicable)**:
+    *   If your Python script is called by the main `sentinel` Bash script (e.g., `sentinel process` calls `sentinel_process.py`), the `sentinel-completion.bash` script should "step aside" when it detects that the `process` subcommand is being completed for its options. It typically does this by returning empty `COMPREPLY` for option arguments of `process`, allowing `argcomplete`'s hooks to take over.
+    *   Ensure the `sentinel` script calls the Python script directly (e.g., `./path/to/script.py "$@"`) rather than via `python ./path/to/script.py "$@"`, as `argcomplete` often relies on the executable name in `COMP_LINE`.
+
+By following these guidelines, developers can extend SENTINEL's autocompletion capabilities effectively, maintaining a consistent and helpful user experience.

--- a/docs/markov_readme.md
+++ b/docs/markov_readme.md
@@ -1,0 +1,137 @@
+# SENTINEL Markov Text Generator
+
+A secure, high-performance Markov chain text generator integrated with the SENTINEL framework. This module uses advanced text analysis and probabilistic models to generate natural-looking text based on input sources.
+
+## Features
+
+- **Intelligent Generation**: Advanced state-based Markov chain text generation
+- **Corpus Management**: Add, list, and analyze corpus files
+- **Secure Processing**: Validation of inputs and secure file handling
+- **Terminal Integration**: Seamless integration with SENTINEL shell environment
+- **Command Suggestions**: Optional integration with command prediction system
+
+## Installation
+
+The Markov generator is included with SENTINEL. To ensure all dependencies are installed:
+
+```bash
+# Activate the SENTINEL Python environment
+source "$HOME/venv/bin/activate"
+
+# Install dependencies
+pip install markovify numpy tqdm unidecode
+```
+
+Enable the module in SENTINEL:
+
+```bash
+# Add to your modules configuration
+echo "sentinel_markov" >> ~/.bash_modules
+```
+
+## Usage
+
+### Basic Text Generation
+
+Generate text from an input file:
+
+```bash
+sentinel_markov generate -i input.txt -o output.txt -s 3 -c 10
+```
+
+Where:
+- `-i, --input`: Input file path (required)
+- `-o, --output`: Output file path (optional)
+- `-s, --state-size`: Markov chain state size (default: 2)
+- `-c, --count`: Number of sentences to generate (default: 5)
+- `-l, --max-length`: Maximum sentence length (default: 280)
+
+### Corpus Management
+
+Add a file to the corpus:
+
+```bash
+sentinel_markov corpus ~/Documents/sample.txt
+```
+
+List all corpus files:
+
+```bash
+sentinel_markov list
+```
+
+View corpus statistics:
+
+```bash
+sentinel_markov corpus-stats
+```
+
+Clean cached data:
+
+```bash
+sentinel_markov clean
+```
+
+## Advanced Configuration
+
+The Markov generator can be customized through its configuration file. The default configuration is created on first run, but you can modify it to adjust behavior:
+
+```json
+{
+    "state_size": 2,
+    "default_count": 5,
+    "max_length": 280,
+    "retention_ratio": 1.0,
+    "extensions": [".txt", ".md", ".rst"],
+    "security": {
+        "max_file_size": 10485760,
+        "validate_input": true,
+        "log_level": "info"
+    }
+}
+```
+
+## Technical Details
+
+### Algorithm
+
+The generator uses a state-based Markov chain that:
+
+1. Analyzes input text and builds probabilistic state transitions
+2. Generates new sequences based on learned probability distributions
+3. Applies validation rules to ensure output quality and security
+
+### Security Features
+
+- Input validation and sanitization
+- File size limits and format validation
+- ASCII conversion to prevent unicode-based issues
+- Permissioned file operations
+
+## Integration with SENTINEL
+
+The Markov generator integrates with other SENTINEL features:
+
+- **Command Prediction**: Can suggest commands based on Markov analysis of shell history
+- **Module System**: Respects SENTINEL's module dependency management
+- **Logging System**: Integrates with SENTINEL's logging infrastructure
+
+## Troubleshooting
+
+- **Empty Output**: Input may be too small or contain incompatible formatting
+- **Slow Performance**: Reduce state size or input file size
+- **Permissions Errors**: Check file permissions in ${HOME}/markov/
+- **Missing Dependencies**: Ensure all Python packages are installed
+
+For detailed logs, check:
+```bash
+cat ${HOME}/logs/markov_generator.log
+```
+
+## License
+
+This component is part of the SENTINEL project and is subject to the same license terms.
+
+## Authors
+
+- SENTINEL Team

--- a/docs/tests_readme.md
+++ b/docs/tests_readme.md
@@ -1,0 +1,3 @@
+﻿## bashrc testing
+This folder includes various scripts and helpers for developing bashrc.
+Normal users probably don't need any of this.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,0 +1,21 @@
+## This is a TODO list
+
+
+## DISTCC - AUTOMAKE
+Add module to set the right environment for using Distcc
+Ex:
+export PATH="/usr/lib/ccache/bin:/usr/lib/distcc/bin:${PATH}"
+
+## Advanced Machine Learning
+✅ Add cybersecurity machine learning module for code vulnerability detection
+✅ Enhance model training with pre-trained embeddings (GloVe 100d integrated, config set)
+- Add support for more programming languages
+- Create visualization dashboard for security findings
+- Integrate with CI/CD pipeline tools
+
+## Markov Text Generation
+✅ Add Markov chain text generator module with security features
+- Integrate with GitStar analyzer for project documentation generation
+- Create semantic document clustering for corpus management
+- Add OpenVINO acceleration for larger models
+- Implement web API interface for remote generation


### PR DESCRIPTION
- Gathered existing READMEs and other Markdown documentation files.
- Created a new docs/ folder to house all project documentation.
- Organized files into docs/, including main_readme.md, installation.md, todo.md, errors.md, contrib_readme.md, tests_readme.md, and markov_readme.md.
- Created docs/README.md as a central index for all documentation.
- Created docs/external_git_readmes_index.md to point to the extensive collection of external readmes in gitstar/readmes/, avoiding duplication in the docs/ folder.
- Corrected internal links within the moved files, particularly in main_readme.md, and noted missing linked files.