### PR TITLE
Fix: Set LANG and LC_ALL in bashrc.postcustom to en_US.UTF-8

### DIFF
--- a/bashrc.postcustom
+++ b/bashrc.postcustom
@@ -1,3 +1,6 @@
+export LANG=en_US.UTF-8
+export LC_ALL=en_US.UTF-8
+
 #!/usr/bin/env bash
 # ~/bashrc.postcustom
 #


### PR DESCRIPTION
This change addresses warnings related to incorrect locale settings by explicitly setting LANG and LC_ALL to en_US.UTF-8 in the bashrc.postcustom file. This aims to resolve issues where Qt applications report locale problems and to provide a more consistent UTF-8 environment.