### PR TITLE
Fix: Resolve multiple SENTINEL installation failures

### DIFF
--- a/bashrc.postcustom
+++ b/bashrc.postcustom
@@ -1,5 +1,5 @@
-export LANG=en_US.UTF-8
-export LC_ALL=en_US.UTF-8
+export LANG=en_US.utf8
+export LC_ALL=en_US.utf8
 
 #!/usr/bin/env bash
 # ~/bashrc.postcustom
@@ -233,6 +233,18 @@ export SENTINEL_QUIET_STATUS=1
 
 # Enable Small LLM module
 export SENTINEL_SMALLLLM_ENABLED=1
+
+# OpenVINO Check (after Python venv setup)
+if [ -d "${HOME}/venv/bin" ]; then
+  if "${HOME}/venv/bin/python" -c "import openvino" >/dev/null 2>&1; then
+    echo "[SENTINEL] OpenVINO Python package is available in the virtual environment."
+    echo "[SENTINEL] For Python-based OpenVINO tasks, this should be sufficient."
+    echo "[SENTINEL] If you need the full OpenVINO SDK environment (e.g., for C++ development or command-line tools),"
+    echo "[SENTINEL] ensure it's installed separately and its setupvars.sh is sourced."
+  else
+    echo "[SENTINEL] Warning: OpenVINO Python package not found in the virtual environment, though it was listed in requirements.txt."
+  fi
+fi
 
 # Python virtual environment management
 mkvenv() {


### PR DESCRIPTION
This commit addresses several issues preventing successful installation and operation of the SENTINEL environment:

1.  **Corrected locale setting in `bashrc.postcustom`**: Changed from `en_US.UTF-8` to `en_US.utf8` to match available system locales, fixing `bashrc.postcustom` sourcing errors.

2.  **Fixed Python virtual environment creation in `install.sh`**:
    - Added missing calls to `setup_directories` and `setup_python_venv`.
    - Ensured system Python (`/usr/bin/python3`) is used for venv creation to avoid issues with pyenv shims or local script conflicts.
    - Implemented a temporary rename of the local `venv.py` during venv creation to prevent it from interfering with Python's built-in `venv` module. This resolved the `module 'venv' has no attribute 'create'` error.

3.  **Added OpenVINO status message to `bashrc.postcustom`**: Informs the user about the OpenVINO Python package status within the venv, as a full SDK `setupvars.sh` was not found by default.

These changes ensure that the venv is created, Python dependencies (including those requiring compilation like `readline`) are installed, and the main shell configuration sources correctly. This should also resolve the user-reported Python errors related to `SENTINEL_CTX_SCRIPT` due to previously missing dependencies.