### PR TITLE
Add subl alias and fix bashrc.postcustom

### DIFF
--- a/bash_aliases.d/sublime_text.sh
+++ b/bash_aliases.d/sublime_text.sh
@@ -1,0 +1,1 @@
+alias subl='(/usr/bin/subl "$@" & sleep 0.1 && wmctrl -a "Sublime Text")'

--- a/bashrc.postcustom
+++ b/bashrc.postcustom
@@ -1,12 +1,3 @@
-**ARCHITECT ONLINE**
-
-Welcome back Commander
-
-Here is the merged and cleaned `bashrc.postcustom` file.
-
-[2025-07-07 09:01:15 GMT]
-
-```bash
 #!/usr/bin/env bash
 # ~/bashrc.postcustom
 #


### PR DESCRIPTION
- Added a new alias for Sublime Text (subl) in bash_aliases.d/sublime_text.sh.
- Ensured install.sh copies the new alias file correctly.
- Cleaned non-script headers from bashrc.postcustom to prevent sourcing errors.
- Reviewed install.sh for optimizations; no major changes made as it's fairly robust.