### PR TITLE
feat: Implement custom OpenVINO sourcing strategy

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,0 +1,2 @@
+# Using custom OpenVINO build - do not install via pip
+openvino==0.0.0

--- a/install.sh
+++ b/install.sh
@@ -382,6 +382,16 @@ setup_python_venv() {
             if [[ -z "$package" ]]; then
                 continue
             fi
+
+            # Check for OpenVINO constraint
+            if [[ "$package" == openvino* ]]; then
+                local constraints_file="${PROJECT_ROOT}/constraints.txt"
+                if [[ -f "$constraints_file" ]] && grep -qxF "openvino==0.0.0" "$constraints_file"; then
+                    log "Skipping OpenVINO installation due to constraint in $constraints_file"
+                    continue
+                fi
+            fi
+
             step "Attempting to install $package..."
             if "$VENV_DIR/bin/pip" install "$package"; then
                 ok "Successfully installed $package"


### PR DESCRIPTION
- Created constraints.txt to prevent pip from installing OpenVINO.
- Modified install.sh to respect the openvino==0.0.0 constraint, ensuring it skips OpenVINO installation from PyPI if the constraint is set.

This allows users to use a custom-compiled OpenVINO by setting up their environment (e.g., via a venv activate script) and prevents the project's standard installation from overriding it.