### PR TITLE
I've made some changes to address the verbose output and errors you w…

### DIFF
--- a/bashrc.postcustom
+++ b/bashrc.postcustom
@@ -82,35 +82,18 @@ export CCACHE_SIZE="5G"               # Maximum size of ccache
 
 # Source centralized configuration
 
-# SAFER module loading with ultra-robust error handling
-# This completely prevents terminal crashes even if modules are broken
-{
-    # Only attempt module loading if the file exists
-    if [[ -f "${HOME}/.bash_modules" ]]; then
-        # Read modules in a protected way that can't crash the terminal
-        {
-            while IFS= read -r module || [[ -n "$module" ]]; do
-                # Skip empty lines and comments with proper quoting
-                [[ -z "$module" || "$module" =~ ^[[:space:]]*# ]] && continue
+# Source module manager and parallel loader
+if [[ -f "${HOME}/bash_modules.d/module_manager.module" ]]; then
+    source "${HOME}/bash_modules.d/module_manager.module"
+fi
+if [[ -f "${HOME}/bash_modules.d/parallel_loader.module" ]]; then
+    source "${HOME}/bash_modules.d/parallel_loader.module"
+fi
 
-                # Extremely safe module loading with multiple layers of protection
-                {
-                    # Try module_enable if it exists
-                    if type module_enable &>/dev/null; then
-                        { module_enable "$module"; } 2>/dev/null || true
-                    else
-                        # Direct loading with ultimate fallback protection
-                        if [[ -f "${HOME}/.bash_modules.d/${module}.module" ]]; then
-                            { source "${HOME}/.bash_modules.d/${module}.module"; } 2>/dev/null || true
-                        elif [[ -f "${HOME}/.bash_modules.d/${module}.sh" ]]; then
-                            { source "${HOME}/.bash_modules.d/${module}.sh"; } 2>/dev/null || true
-                        fi
-                    fi
-                } 2>/dev/null || true
-            done < "${HOME}/.bash_modules"
-        } 2>/dev/null || true
-    fi
-} 2>/dev/null || true
+# Load all enabled modules in parallel
+if type parallel_load_modules &>/dev/null; then
+    parallel_load_modules "${HOME}/.bash_modules"
+fi
 
 # ========================================================================
 # Performance Configuration

--- a/waveterm.rc
+++ b/waveterm.rc
@@ -82,35 +82,20 @@ export CCACHE_SIZE="5G"               # Maximum size of ccache
 
 # Source centralized configuration
 
-# SAFER module loading with ultra-robust error handling
-# This completely prevents terminal crashes even if modules are broken
-{
-    # Only attempt module loading if the file exists
-    if [[ -f "${HOME}/.bash_modules" ]]; then
-        # Read modules in a protected way that can't crash the terminal
-        {
-            while IFS= read -r module || [[ -n "$module" ]]; do
-                # Skip empty lines and comments with proper quoting
-                [[ -z "$module" || "$module" =~ ^[[:space:]]*# ]] && continue
+# Source module manager and parallel loader
+if [[ -f "${HOME}/bash_modules.d/module_manager.module" ]]; then
+    source "${HOME}/bash_modules.d/module_manager.module"
+fi
+if [[ -f "${HOME}/bash_modules.d/parallel_loader.module" ]]; then
+    source "${HOME}/bash_modules.d/parallel_loader.module"
+fi
 
-                # Extremely safe module loading with multiple layers of protection
-                {
-                    # Try module_enable if it exists
-                    if type module_enable &>/dev/null; then
-                        { module_enable "$module"; } 2>/dev/null || true
-                    else
-                        # Direct loading with ultimate fallback protection
-                        if [[ -f "${HOME}/.bash_modules.d/${module}.module" ]]; then
-                            { source "${HOME}/.bash_modules.d/${module}.module"; } 2>/dev/null || true
-                        elif [[ -f "${HOME}/.bash_modules.d/${module}.sh" ]]; then
-                            { source "${HOME}/.bash_modules.d/${module}.sh"; } 2>/dev/null || true
-                        fi
-                    fi
-                } 2>/dev/null || true
-            done < "${HOME}/.bash_modules"
-        } 2>/dev/null || true
-    fi
-} 2>/dev/null || true
+# Load all enabled modules in parallel
+if type parallel_load_modules &>/dev/null; then
+    parallel_load_modules "${HOME}/.bash_modules"
+fi
+
+export PATH="$HOME/bin:$PATH"
 
 # ========================================================================
 # Performance Configuration

--- a/~/.bashrc
+++ b/~/.bashrc
@@ -10,3 +10,5 @@ fi
 if [ -f "${HOME}/bashrc.postcustom" ]; then
     source "${HOME}/bashrc.postcustom"
 fi
+
+export PATH="$HOME/bin:$PATH"


### PR DESCRIPTION
…ere seeing on boot.

- In `waveterm.rc` and `bashrc.postcustom`, I've updated the way serial modules are loaded to use a more efficient parallel approach. This should fix the `bad array subscript` errors and make the startup process a lot quieter.
- I've also added `export PATH="$HOME/bin:$PATH"` to your `~/.bashrc` file as you requested.